### PR TITLE
Add msgtype key to configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# matrix-send
+Send messages to matrix from command line
+
+copy config.ini.template
+```
+[DEFAULT]
+endpoint=https://matrix-server:8448/_matrix/
+access_token=
+channel_id=
+``` 
+

--- a/README.md
+++ b/README.md
@@ -1,11 +1,24 @@
 # matrix-send
-Send messages to matrix from command line
 
-copy config.ini.template
+Send messages to matrix from command line. Usage example:
+
+```
+$ ./matrix-send.py "Hello world!"
+```
+
+## Configuration
+
+Copy the config.ini.template file to ```~/.config/matrix-send/config.ini``` and fill the fields:
+
 ```
 [DEFAULT]
 endpoint=https://matrix-server:8448/_matrix/
 access_token=
 channel_id=
-``` 
+msgtype=m.notice
+```
 
+### Getting the access_token and channel_id values
+
+Please, refer to matrix' documentation:
+https://matrix.org/docs/guides/client-server.html

--- a/config.ini.template
+++ b/config.ini.template
@@ -2,3 +2,4 @@
 endpoint=https://matrix-server:8448/_matrix/
 access_token=
 channel_id=
+msgtype=m.notice

--- a/matrix-send.py
+++ b/matrix-send.py
@@ -15,7 +15,7 @@ import os
 def url_quote(input: str) -> str:
     return urllib.parse.quote_plus(input)
 
-def send_message(endpoint: str, access_token: str, channel_id: str, message: str, timeout: int) -> bool:
+def send_message(endpoint: str, access_token: str, channel_id: str, msgtype: str, message: str, timeout: int) -> bool:
     message_id = datetime.now().strftime("m%s.%f")
     ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLSv1_2)
     url = "{endpoint}client/r0/rooms/{channel_id}/send/m.room.message/{message_id}?access_token={access_token}".format(
@@ -24,7 +24,7 @@ def send_message(endpoint: str, access_token: str, channel_id: str, message: str
         message_id=url_quote(message_id),
         access_token=url_quote(access_token)
     )
-    body = json.dumps({"msgtype": "m.notice",
+    body = json.dumps({"msgtype": msgtype,
                        "format": "org.matrix.custom.html",
                        "body": message,
                        "formatted_body": message}).encode()
@@ -52,6 +52,7 @@ def main(argv: List[str]):
     endpoint = default['endpoint'] # type: str
     access_token = default['access_token'] # type: str
     channel_id = default['channel_id'] # type: str
+    msgtype = default.get('msgtype', 'm.notice') # type: str
     timeout = int(default.get('timeout', "10"))
 
     if args.message is None:
@@ -63,6 +64,7 @@ def main(argv: List[str]):
     if send_message(endpoint=endpoint,
                     access_token=access_token,
                     channel_id=channel_id,
+                    msgtype=msgtype,
                     message=message,
                     timeout=timeout):
         return 0


### PR DESCRIPTION
By default, we keep using m.notice but we can set it, for example, to
m.text:
https://matrix.org/docs/spec/client_server/latest.html#m-room-message-msgtypes

This is interesting to, for example, prevent the special treatment
applied to the m.notice msgtype.